### PR TITLE
Adds basic 'open directory' support

### DIFF
--- a/ze.c
+++ b/ze.c
@@ -78,6 +78,7 @@ _true (const struct dirent *empty) {
 	// In order to fix a compiler warning, we need to make sure that the
 	// signature of our _true function matches what the scandir function
 	// expects. Therefore, we have to accept an argument that we don't use.
+  (void)empty;
 	return 1;
 }
 


### PR DESCRIPTION
If a file path to a directory is supplied when invoking C-o, then instead of crashing, this instead lists the contents of the directory.